### PR TITLE
[LEGIT] Fix - js/code-injection

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -21,9 +21,9 @@ function ContributionsHandler (db) {
 
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        const preTax = parseInt(req.body.preTax, 10);
+        const afterTax = parseInt(req.body.afterTax, 10);
+        const roth = parseInt(req.body.roth, 10);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval


### PR DESCRIPTION
# 🔍 The problem

Code injection
[See issue in Legit](https://demo5.legitsecurity.net/app/issues?viewBy=AllIssues&isAdvanced=1&queryState=%7B%22entityId%22%3A%22Issue%22%2C%22attributeGroupFilter%22%3A%7B%22logicalOperator%22%3A%22And%22%2C%22groups%22%3A%5B%7B%22logicalOperator%22%3A%22And%22%2C%22filters%22%3A%5B%7B%22attributeId%22%3A%22status%22%2C%22value%22%3A%5B%22OPEN%22%5D%2C%22operator%22%3A%22Is%22%7D%2C%7B%22attributeId%22%3A%22aiRemediation%22%2C%22value%22%3A%5B%22GENERATED%22%5D%2C%22operator%22%3A%22Is+one+of%22%7D%5D%7D%5D%7D%7D&selectedIssue=f1bee2ea-8e65-4a77-87ca-3c66247a3c68&selectedIssueType=SAST&currentTab=remediation#iss=https%3A%2F%2Fdemo5.legitsecurity.net%2Fauth%2Frealms%2Fdemo5&iss=https%3A%2F%2Fdemo5.legitsecurity.net%2Fauth%2Frealms%2Fdemo5&state=3ad4829b-0dbd-4112-9261-cd9c65d00739&session_state=ce8a52d5-e54d-490b-98ba-a0ceff243638&iss=https%3A%2F%2Fdemo5.legitsecurity.net%2Fauth%2Frealms%2Fdemo5&code=7917a663-058c-4fa6-9889-bf77ed6bb078.ce8a52d5-e54d-490b-98ba-a0ceff243638.e7e2de77-92bc-491c-8d9c-c3bbf2670379)

# 🔒 Fix Details

The code uses `eval()` to parse user inputs, which is a security risk as it can lead to code injection vulnerabilities. The fix replaces `eval()` with `parseInt()` to safely convert the input strings to integers, ensuring that only numeric values are processed.
```diff
diff --git a/app/routes/contributions.js b/app/routes/contributions.js
index 7b8f9c3..d4e5f6a 100644
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -22,7 +22,7 @@ function ContributionsHandler (db) {
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        const preTax = parseInt(req.body.preTax, 10);
+        const afterTax = parseInt(req.body.afterTax, 10);
+        const roth = parseInt(req.body.roth, 10);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval

```