### PR TITLE
[LEGIT] Fix - javascript.express.code.eval-express.eval-express

### DIFF
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -21,9 +21,9 @@ function ContributionsHandler (db) {
 
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        const preTax = parseInt(req.body.preTax);
+        const afterTax = parseInt(req.body.afterTax);
+        const roth = parseInt(req.body.roth);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval


### PR DESCRIPTION
# 🔍 The problem

The application might dynamically evaluate untrusted input, which can lead to a code injection vulnerability. An attacker can execute arbitrary code, potentially gaining complete control of the system. To prevent this vulnerability, avoid executing code containing user input. If this is unavoidable, validate and sanitize the input, and use safe alternatives for evaluating user input.
[See issue in Legit](https://demo5.legitsecurity.net/app/agents)

# 🔒 Fix Details

The vulnerability arises from the use of `eval()` to parse user input, which can lead to code injection attacks. To remediate this, we replace the `eval()` calls with `parseInt()` to safely parse the input as integers. This approach prevents arbitrary code execution while preserving the intended functionality of parsing numeric input. The commented-out code already contains the safer alternative, so we will activate that and remove the unsafe `eval()` lines.
```diff
--- a/app/routes/contributions.js
+++ b/app/routes/contributions.js
@@ -21,9 +21,9 @@
 
         /*jslint evil: true */
         // Insecure use of eval() to parse inputs
-        const preTax = eval(req.body.preTax);
-        const afterTax = eval(req.body.afterTax);
-        const roth = eval(req.body.roth);
+        const preTax = parseInt(req.body.preTax);
+        const afterTax = parseInt(req.body.afterTax);
+        const roth = parseInt(req.body.roth);
 
         /*
         //Fix for A1 -1 SSJS Injection attacks - uses alternate method to eval

```